### PR TITLE
FEATURE: expose current key in withItems iteration

### DIFF
--- a/Classes/Template.php
+++ b/Classes/Template.php
@@ -131,10 +131,11 @@ class Template
             $items = explode(',', $items);
         }
 
-        foreach ($items as $item) {
+        foreach ($items as $key => $item) {
             // only set item context if withItems is set in template to prevent losing item context from parent template
             if ($this->withItems) {
                 $context['item'] = $item;
+                $context['key'] = $key;
             }
             $node = null;
             $name = $this->name;


### PR DESCRIPTION
Usage example:


```
    template:
      childNodes:
        image:
          name: '${"image" + key}'
          type: 'Psmb.NodeTypes:Image'
          properties:
            image: '${item}'
          withItems: '${data.images}'
```