### PR TITLE
FEATURE: make node creation depth configurable

### DIFF
--- a/Classes/NodeCreationHandler/TemplateNodeCreationHandler.php
+++ b/Classes/NodeCreationHandler/TemplateNodeCreationHandler.php
@@ -18,6 +18,12 @@ class TemplateNodeCreationHandler implements NodeCreationHandlerInterface
     protected $propertyMapper;
 
     /**
+     * @var integer
+     * @Flow\InjectConfiguration(path="nodeCreationDepth")
+     */
+    protected $nodeCreationDepth;
+
+    /**
      * Create child nodes and change properties upon node creation
      *
      * @param NodeInterface $node The newly created node
@@ -35,7 +41,7 @@ class TemplateNodeCreationHandler implements NodeCreationHandlerInterface
         $propertyMappingConfiguration = $this->propertyMapper->buildPropertyMappingConfiguration();
 
         $subPropertyMappingConfiguration = $propertyMappingConfiguration;
-        for ($i = 0; $i < 10; $i++) {
+        for ($i = 0; $i < $this->nodeCreationDepth; $i++) {
             $subPropertyMappingConfiguration = $subPropertyMappingConfiguration
                 ->forProperty('childNodes.*')
                 ->allowAllProperties();

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -11,3 +11,4 @@ Flowpack:
       Translation: 'Neos\Flow\I18n\EelHelper\TranslationHelper'
       Type: 'Neos\Eel\Helper\TypeHelper'
       I18n: 'Neos\Flow\I18n\EelHelper\TranslationHelper'
+    nodeCreationDepth: 10

--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ There are several variables available in the EEL context that allow for accessin
 | item           | The current item inside a withItems loop                                                  | Inside withItems loop   |
 | key            | The current key inside a withItems loop                                                   | Inside withItems loop   |
 
+## Node creation depth
+
+The node creation depth can be configured via Settings.yaml with `nodeCreationDepth`, defaults to `10`. 
+
+```yaml
+Flowpack:
+  NodeTemplates:
+    nodeCreationDepth: 10
+``` 
+
 ## More examples
 
 For more examples have a look at the node templates demo package:


### PR DESCRIPTION
For nodeTemplate with a childNode depth greater than 10 the node creation fails.
This feature introduces a setting for the childNode creation depth.