### PR TITLE
BUGFIX: Allow set of uriPathSegment via template

### DIFF
--- a/Classes/NodeCreationHandler/TemplatingDocumentTitleNodeCreationHandler.php
+++ b/Classes/NodeCreationHandler/TemplatingDocumentTitleNodeCreationHandler.php
@@ -68,7 +68,7 @@ class TemplatingDocumentTitleNodeCreationHandler implements NodeCreationHandlerI
             }
         }
 
-        if (!$uriPathSegment) {
+        if (!isset($uriPathSegment) || $uriPathSegment === '') {
             $uriPathSegment = $title;
         }
 


### PR DESCRIPTION
This PR solves #25.

I left the function `generateUriPathSegment` as it is, to make sure to have correct URI, even when the string from the template is not correct.