### PR TITLE
BUGFIX: Re-add FlowQuery to the EelContext

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -11,4 +11,5 @@ Flowpack:
       Translation: 'Neos\Flow\I18n\EelHelper\TranslationHelper'
       Type: 'Neos\Eel\Helper\TypeHelper'
       I18n: 'Neos\Flow\I18n\EelHelper\TranslationHelper'
+      q: 'Neos\Eel\FlowQuery\FlowQuery::q'
     nodeCreationDepth: 10

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "name": "flowpack/nodetemplates",
     "license": "GPL-3.0+",
     "require": {
+        "neos/neos": "^5.0",
         "neos/neos-ui": "*"
     },
     "autoload": {


### PR DESCRIPTION
With https://github.com/neos/neos-development-collection/commit/02b64792d1f70360fb11241b89b1e8c0f181cc46 the 'magic' q was removed and an eel-helper was added to the default context. This eel helper needs to be added to this context as well