### PR TITLE
TASK: Drop eel evaluation on properties with value of type array

### DIFF
--- a/Classes/Template.php
+++ b/Classes/Template.php
@@ -201,7 +201,8 @@ class Template
     protected function setProperties(NodeInterface $node, array $context)
     {
         foreach ($this->properties as $propertyName => $propertyValue) {
-            if (preg_match(\Neos\Eel\Package::EelExpressionRecognizer, $propertyValue)) {
+            //evaluate Eel only on string properties
+            if (is_string($propertyValue) && preg_match(\Neos\Eel\Package::EelExpressionRecognizer, $propertyValue)) {
                 $this->persistenceManager->persistAll();
                 $propertyValue = $this->eelEvaluationService->evaluateEelExpression($propertyValue, $context);
             }


### PR DESCRIPTION
Hi, this is a little change that prevents a warning when setting a property of type array.