### PR TITLE
BUGFIX: Parse EEL Expressions in "type"

### DIFF
--- a/Classes/Template.php
+++ b/Classes/Template.php
@@ -158,9 +158,12 @@ class Template
                 $flowQuery = new FlowQuery(array($parentNode));
                 $node = $flowQuery->find($name)->get(0);
             }
+            $type = $this->type;
+            if (preg_match(\Neos\Eel\Package::EelExpressionRecognizer, $type)) {
+                $type = $this->eelEvaluationService->evaluateEelExpression($this->type, $context);
+            }
             if (!$node instanceof NodeInterface) {
-                $node = $this->nodeOperations->create($parentNode, ['nodeType' => $this->type, 'nodeName' => $name],
-                    'into');
+                $node = $this->nodeOperations->create($parentNode, ['nodeType' => $type, 'nodeName' => $name], 'into');
 
                 // All document node types get a uri path segment; if it is not explicitly set in the properties,
                 // it should be built based on the title property

--- a/Classes/Template.php
+++ b/Classes/Template.php
@@ -158,11 +158,11 @@ class Template
                 $flowQuery = new FlowQuery(array($parentNode));
                 $node = $flowQuery->find($name)->get(0);
             }
-            $type = $this->type;
-            if (preg_match(\Neos\Eel\Package::EelExpressionRecognizer, $type)) {
-                $type = $this->eelEvaluationService->evaluateEelExpression($this->type, $context);
-            }
             if (!$node instanceof NodeInterface) {
+                $type = $this->type;
+                if (preg_match(\Neos\Eel\Package::EelExpressionRecognizer, $type)) {
+                    $type = $this->eelEvaluationService->evaluateEelExpression($this->type, $context);
+                }
                 $node = $this->nodeOperations->create($parentNode, ['nodeType' => $type, 'nodeName' => $name], 'into');
 
                 // All document node types get a uri path segment; if it is not explicitly set in the properties,

--- a/Classes/Template.php
+++ b/Classes/Template.php
@@ -161,7 +161,7 @@ class Template
             if (!$node instanceof NodeInterface) {
                 $type = $this->type;
                 if (preg_match(\Neos\Eel\Package::EelExpressionRecognizer, $type)) {
-                    $type = $this->eelEvaluationService->evaluateEelExpression($this->type, $context);
+                    $type = $this->eelEvaluationService->evaluateEelExpression($type, $context);
                 }
                 $node = $this->nodeOperations->create($parentNode, ['nodeType' => $type, 'nodeName' => $name], 'into');
 


### PR DESCRIPTION
Currently the field `type` does not allow eel expressions:

```yaml
childNodes:
  product-details:
    type: "${data.isSpecial ? 'My.Site:NodeType' : 'My.Site:NodeType.Special'}"
    properties:
       foo: bar
```

It might seem to be an odd usecase, as the property overlap of two different nodeTypes might not be that high. Nevertheless i have a usecase for it and want it, and dont think we necessarily need to restrict it to simple strings only.