### PR TITLE
FEATURE: Create node template definition yaml dump from node subtree

### DIFF
--- a/Classes/Command/NodeTemplateCommandController.php
+++ b/Classes/Command/NodeTemplateCommandController.php
@@ -24,14 +24,14 @@ class NodeTemplateCommandController extends CommandController
     protected $nodeTemplateDumper;
 
     /**
-     * Dump the node tree structure into a NodeTemplate Yaml structure.
-     * References to Nodes and non-primitive property values are commented out in the Yaml.
+     * Dump the node tree structure into a NodeTemplate YAML structure.
+     * References to Nodes and non-primitive property values are commented out in the YAML.
      *
      * @param string $startingNodeId specified root node of the node tree
      * @param string $workspaceName
      * @return void
      */
-    public function fromSubtreeCommand(string $startingNodeId, string $workspaceName = 'live'): void
+    public function createFromNodeSubtree(string $startingNodeId, string $workspaceName = 'live'): void
     {
         $subgraph = $this->contentContextFactory->create([
             'workspaceName' => $workspaceName

--- a/Classes/Command/NodeTemplateCommandController.php
+++ b/Classes/Command/NodeTemplateCommandController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\NodeTemplates\Command;
+
+use Flowpack\NodeTemplates\NodeTemplateDumper\NodeTemplateDumper;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Cli\CommandController;
+use Neos\Neos\Domain\Service\ContentContextFactory;
+
+class NodeTemplateCommandController extends CommandController
+{
+    /**
+     * @Flow\Inject
+     * @var ContentContextFactory
+     */
+    protected $contentContextFactory;
+
+    /**
+     * @Flow\Inject
+     * @var NodeTemplateDumper
+     */
+    protected $nodeTemplateDumper;
+
+    /**
+     * Dump the node tree structure into a NodeTemplate Yaml structure.
+     * References to Nodes and non-primitive property values are commented out in the Yaml.
+     *
+     * @param string $startingNodeId specified root node of the node tree
+     * @param string $workspaceName
+     * @return void
+     */
+    public function fromSubtreeCommand(string $startingNodeId, string $workspaceName = 'live'): void
+    {
+        $subgraph = $this->contentContextFactory->create([
+            'workspaceName' => $workspaceName
+        ]);
+        $node = $subgraph->getNodeByIdentifier($startingNodeId);
+        if (!$node) {
+            throw new \InvalidArgumentException("Node $startingNodeId doesnt exist in workspace $workspaceName.");
+        }
+        echo $this->nodeTemplateDumper->createNodeTemplateYamlDumpFromSubtree($node);
+    }
+}

--- a/Classes/NodeTemplateDumper/Comment.php
+++ b/Classes/NodeTemplateDumper/Comment.php
@@ -4,13 +4,29 @@ declare(strict_types=1);
 
 namespace Flowpack\NodeTemplates\NodeTemplateDumper;
 
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * Wrapper around a comment render function
+ * {@see Comments}
+ *
+ * @Flow\Proxy(false)
+ */
 class Comment
 {
     private \Closure $renderFunction;
 
-    public function __construct(\Closure $renderFunction)
+    private function __construct(\Closure $renderFunction)
     {
         $this->renderFunction = $renderFunction;
+    }
+
+    /**
+     * @psalm-param callable(string $indentation, string $propertyName): string $renderFunction
+     */
+    public static function fromRenderer($renderFunction): self
+    {
+        return new self($renderFunction);
     }
 
     public function toYamlComment(string $indentation, string $propertyName): string

--- a/Classes/NodeTemplateDumper/Comment.php
+++ b/Classes/NodeTemplateDumper/Comment.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\NodeTemplates\NodeTemplateDumper;
+
+class Comment
+{
+    private \Closure $renderFunction;
+
+    public function __construct(\Closure $renderFunction)
+    {
+        $this->renderFunction = $renderFunction;
+    }
+
+    public function toYamlComment(string $indentation, string $propertyName): string
+    {
+        return ($this->renderFunction)($indentation, $propertyName);
+    }
+}

--- a/Classes/NodeTemplateDumper/CommentService.php
+++ b/Classes/NodeTemplateDumper/CommentService.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\NodeTemplates\NodeTemplateDumper;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Utility\Algorithms;
+
+/** @Flow\Scope("singleton") */
+class CommentService
+{
+    private const SERIALIZED_PATTERN = <<<'REGEX'
+    /(?<indentation>[ ]*)(?<property>.*?): Comment<(?<identifier>[a-z0-9\-]{1,255})>/
+    REGEX;
+
+    /** @var array<Comment> */
+    private array $comments;
+
+    public function serialize(\Closure $commentRenderFunction): string
+    {
+        $identifier = Algorithms::generateUUID();
+        $comment = new Comment($commentRenderFunction);
+        $this->comments[$identifier] = $comment;
+        return 'Comment<' . $identifier . '>';
+    }
+
+    public function renderCommentsInYamlDump(string $yamlDump): string
+    {
+        return preg_replace_callback(self::SERIALIZED_PATTERN, function (array $matches) {
+            [
+                'indentation' => $indentation,
+                'property' => $property,
+                'identifier' => $identifier
+            ] = $matches;
+            $comment = $this->comments[$identifier] ?? null;
+            if (!$comment instanceof Comment) {
+                throw new \Exception('Error while trying to render comment ' . $matches[0] . ' commentId doesnt exist.', 1684309524383);
+            }
+            return $comment->toYamlComment($indentation, $property);
+        }, $yamlDump);
+    }
+}

--- a/Classes/NodeTemplateDumper/Comments.php
+++ b/Classes/NodeTemplateDumper/Comments.php
@@ -50,7 +50,7 @@ class Comments
             ] = $matches;
             $comment = $this->comments[$identifier] ?? null;
             if (!$comment instanceof Comment) {
-                throw new \Exception('Error while trying to render comment ' . $matches[0] . ' commentId doesnt exist.', 1684309524383);
+                throw new \Exception('Error while trying to render comment ' . $matches[0] . '. Reason: comment id doesnt exist.', 1684309524383);
             }
             return $comment->toYamlComment($indentation, $property);
         }, $yamlDump);

--- a/Classes/NodeTemplateDumper/NodeTemplateDumper.php
+++ b/Classes/NodeTemplateDumper/NodeTemplateDumper.php
@@ -48,9 +48,9 @@ class NodeTemplateDumper
         assert(isset($firstEntry));
 
         $templateRoot = [
-            "template" => array_filter([
-                "properties" => $firstEntry["properties"] ?? null,
-                "childNodes" => $firstEntry["childNodes"] ?? null,
+            'template' => array_filter([
+                'properties' => $firstEntry['properties'] ?? null,
+                'childNodes' => $firstEntry['childNodes'] ?? null,
             ])
         ];
 
@@ -69,14 +69,14 @@ class NodeTemplateDumper
         foreach ($nodes as $index => $node) {
             assert($node instanceof NodeInterface);
             $nodeType = $node->getNodeType();
-            $isDocumentNode = $nodeType->isOfType("Neos.Neos:Document");
+            $isDocumentNode = $nodeType->isOfType('Neos.Neos:Document');
 
             $templatePart = array_filter([
-                "properties" => $this->nonDefaultConfiguredNodeProperties($node, $comments),
-                "childNodes" => $this->nodeTemplateFromNodes(
+                'properties' => $this->nonDefaultConfiguredNodeProperties($node, $comments),
+                'childNodes' => $this->nodeTemplateFromNodes(
                     $isDocumentNode
-                        ? $node->getChildNodes("Neos.Neos:Content,Neos.Neos:ContentCollection,Neos.Neos:Document")
-                        : $node->getChildNodes("Neos.Neos:Content,Neos.Neos:ContentCollection"),
+                        ? $node->getChildNodes('Neos.Neos:Content,Neos.Neos:ContentCollection,Neos.Neos:Document')
+                        : $node->getChildNodes('Neos.Neos:Content,Neos.Neos:ContentCollection'),
                     $comments
                 )
             ]);
@@ -88,26 +88,26 @@ class NodeTemplateDumper
             if ($isDocumentNode) {
                 if ($node->isTethered()) {
                     $documentNodeTemplates[$node->getLabel() ?: $node->getName()] = array_merge([
-                        "name" => $node->getName()
+                        'name' => $node->getName()
                     ], $templatePart);
                     continue;
                 }
 
                 $documentNodeTemplates["page$index"] = array_merge([
-                    "type" => $node->getNodeType()->getName()
+                    'type' => $node->getNodeType()->getName()
                 ], $templatePart);
                 continue;
             }
 
             if ($node->isTethered()) {
                 $contentNodeTemplates[$node->getLabel() ?: $node->getName()] = array_merge([
-                    "name" => $node->getName()
+                    'name' => $node->getName()
                 ], $templatePart);
                 continue;
             }
 
             $contentNodeTemplates["content$index"] = array_merge([
-                "type" => $node->getNodeType()->getName()
+                'type' => $node->getNodeType()->getName()
             ], $templatePart);
         }
 
@@ -131,8 +131,8 @@ class NodeTemplateDumper
             }
 
             if (
-                array_key_exists("defaultValue", $configuration)
-                && $configuration["defaultValue"] === $nodeProperties[$propertyName]
+                array_key_exists('defaultValue', $configuration)
+                && $configuration['defaultValue'] === $nodeProperties[$propertyName]
             ) {
                 // node property is the same as default
                 continue;
@@ -142,11 +142,11 @@ class NodeTemplateDumper
             if ($propertyValue === null || $propertyValue === []) {
                 continue;
             }
-            if (is_string($propertyValue) && trim($propertyValue) === "") {
+            if (is_string($propertyValue) && trim($propertyValue) === '') {
                 continue;
             }
 
-            $label = $configuration["ui"]["label"] ?? null;
+            $label = $configuration['ui']['label'] ?? null;
             $augmentCommentWithLabel = fn (Comment $comment) => $comment;
             if ($label) {
                 $label = $this->translationHelper->translate($label);
@@ -158,7 +158,7 @@ class NodeTemplateDumper
                 );
             }
 
-            if ($dataSourceIdentifier = $configuration["ui"]["inspector"]["editorOptions"]["dataSourceIdentifier"] ?? null) {
+            if ($dataSourceIdentifier = $configuration['ui']['inspector']['editorOptions']['dataSourceIdentifier'] ?? null) {
                 $filteredProperties[$propertyName] = $comments->addCommentAndGetMarker($augmentCommentWithLabel(Comment::fromRenderer(
                     function ($indentation, $propertyName) use ($dataSourceIdentifier, $propertyValue) {
                         return $indentation . '# ' . $propertyName . ' -> Datasource "' . $dataSourceIdentifier . '" with value ' . $this->valueToDebugString($propertyValue);
@@ -167,21 +167,23 @@ class NodeTemplateDumper
                 continue;
             }
 
-            if (($configuration["type"] ?? null) === "reference") {
-                $nodeTypesInReference = $configuration["ui"]["inspector"]["editorOptions"]["nodeTypes"] ?? ["Neos.Neos:Document"];
+            if (($configuration['type'] ?? null) === 'reference') {
+                $nodeTypesInReference = $configuration['ui']['inspector']['editorOptions']['nodeTypes'] ?? ['Neos.Neos:Document'];
                 $filteredProperties[$propertyName] = $comments->addCommentAndGetMarker($augmentCommentWithLabel(Comment::fromRenderer(
                     function ($indentation, $propertyName) use ($nodeTypesInReference, $propertyValue) {
-                        return $indentation . '# ' . $propertyName . ' -> Reference of NodeTypes (' . join(", ", $nodeTypesInReference) . ') with value ' . $this->valueToDebugString($propertyValue);
+                        return $indentation . '# ' . $propertyName . ' -> Reference of NodeTypes (' . join(', ', $nodeTypesInReference) . ') with value ' . $this->valueToDebugString($propertyValue);
                     }
                 )));
                 continue;
             }
 
-            if (($configuration["ui"]["inspector"]["editor"] ?? null) === 'Neos.Neos/Inspector/Editors/SelectBoxEditor') {
-                $selectBoxValues = array_keys($configuration["ui"]["inspector"]["editorOptions"]["values"] ?? []);
+            if (($configuration['ui']['inspector']['editor'] ?? null) === 'Neos.Neos/Inspector/Editors/SelectBoxEditor') {
+                $selectBoxValues = array_keys($configuration['ui']['inspector']['editorOptions']['values'] ?? []);
                 $filteredProperties[$propertyName] = $comments->addCommentAndGetMarker($augmentCommentWithLabel(Comment::fromRenderer(
                     function ($indentation, $propertyName) use ($selectBoxValues, $propertyValue) {
-                        return $indentation . '# ' . $propertyName . ' -> SelectBox of ' . mb_strimwidth(json_encode($selectBoxValues), 0, 60, " ...]") . ' with value ' . $this->valueToDebugString($propertyValue);
+                        return $indentation . '# ' . $propertyName . ' -> SelectBox of '
+                            . mb_strimwidth(json_encode($selectBoxValues), 0, 60, ' ...]')
+                            . ' with value ' . $this->valueToDebugString($propertyValue);
                     }
                 )));
                 continue;

--- a/Classes/NodeTemplateDumper/NodeTemplateDumper.php
+++ b/Classes/NodeTemplateDumper/NodeTemplateDumper.php
@@ -20,11 +20,11 @@ class NodeTemplateDumper
     protected $translationHelper;
 
     /**
-     * Dump the node tree structure into a NodeTemplate Yaml structure.
-     * References to Nodes and non-primitive property values are commented out in the Yaml.
+     * Dump the node tree structure into a NodeTemplate YAML structure.
+     * References to Nodes and non-primitive property values are commented out in the YAML.
      *
      * @param NodeInterface $startingNode specified root node of the node tree to dump
-     * @return string yaml representation of the node template
+     * @return string YAML representation of the node template
      */
     public function createNodeTemplateYamlDumpFromSubtree(NodeInterface $startingNode): string
     {

--- a/Classes/NodeTemplateDumper/NodeTemplateDumper.php
+++ b/Classes/NodeTemplateDumper/NodeTemplateDumper.php
@@ -47,18 +47,20 @@ class NodeTemplateDumper
         }
         assert(isset($firstEntry));
 
-        $templateRoot = [
-            'template' => array_filter([
-                'properties' => $firstEntry['properties'] ?? null,
-                'childNodes' => $firstEntry['childNodes'] ?? null,
-            ])
+        $templateInNodeTypeOptions = [
+            $nodeType->getName() => [
+                'options' => [
+                    'template' => array_filter([
+                        'properties' => $firstEntry['properties'] ?? null,
+                        'childNodes' => $firstEntry['childNodes'] ?? null,
+                    ])
+                ]
+            ]
         ];
 
-        $yaml = Yaml::dump($templateRoot, 99, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_NULL_AS_TILDE);
+        $yamlWithSerializedComments = Yaml::dump($templateInNodeTypeOptions, 99, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_NULL_AS_TILDE);
 
-        $yamlWithComments = $comments->renderCommentsInYamlDump($yaml);
-
-        return $yamlWithComments;
+        return $comments->renderCommentsInYamlDump($yamlWithSerializedComments);
     }
 
     /** @param array<NodeInterface> $nodes */

--- a/Classes/NodeTemplateDumper/NodeTemplateDumper.php
+++ b/Classes/NodeTemplateDumper/NodeTemplateDumper.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\NodeTemplates\NodeTemplateDumper;
+
+use Neos\ContentRepository\Domain\Model\ArrayPropertyCollection;
+use Neos\ContentRepository\Domain\Model\Node;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\Flow\Annotations as Flow;
+use Symfony\Component\Yaml\Yaml;
+
+/** @Flow\Scope("singleton") */
+class NodeTemplateDumper
+{
+    /**
+     * @Flow\Inject
+     * @var CommentService
+     */
+    protected $commentService;
+
+    /**
+     * Dump the node tree structure into a NodeTemplate Yaml structure.
+     * References to Nodes and non-primitive property values are commented out in the Yaml.
+     *
+     * @param Node|NodeInterface|TraversableNodeInterface $node specified root node of the node tree to dump
+     * @return string yaml representation of the node template
+     */
+    public function createNodeTemplateYamlDumpFromSubtree(Node $node): string
+    {
+        $nodeType = $node->getNodeType();
+        if ($nodeType->isOfType('Neos.Neos:Document')) {
+            $template = $this->nodeTemplateFromDocumentNodes([$node]);
+        } elseif ($nodeType->isOfType('Neos.Neos:Content') || $nodeType->isOfType('Neos.Neos:ContentCollection')) {
+            $template = $this->nodeTemplateFromContentNodes([$node]);
+        } else {
+            throw new \InvalidArgumentException("Node {$node->getIdentifier()} must be one of Neos.Neos:Document,Neos.Neos:Content,Neos.Neos:ContentCollection.");
+        }
+
+        $templateInContext = [
+            "Your.NodeType" => [
+                "options" => [
+                    "template" => [
+                        "childNodes" => $template
+                    ]
+                ]
+            ]
+        ];
+
+        $yaml = Yaml::dump($templateInContext, 99, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE | Yaml::DUMP_NULL_AS_TILDE);
+
+        $yamlWithComments = $this->commentService->renderCommentsInYamlDump($yaml);
+
+        return $yamlWithComments;
+    }
+
+    /** @param array<Node|NodeInterface> $nodes */
+    private function nodeTemplateFromDocumentNodes(array $nodes): array
+    {
+        $template = [];
+        foreach ($nodes as $index => $node) {
+            assert($node instanceof Node);
+
+            if ($node->isTethered()) {
+                throw new \Exception("@todo");
+            }
+
+            $template["page$index"] = array_filter([
+                "name" => "page-$index",
+                "type" => $node->getNodeType()->getName(),
+                "properties" => $this->nonDefaultConfiguredNodeProperties($node),
+                "childNodes" => array_merge(
+                    $this::nodeTemplateFromContentNodes(
+                        $node->getChildNodes("Neos.Neos:Content,Neos.Neos:ContentCollection")
+                    ),
+                    $this::nodeTemplateFromDocumentNodes($node->getChildNodes("Neos.Neos:Document")),
+                )
+            ]);
+        }
+
+        return $template;
+    }
+
+    private function nonDefaultConfiguredNodeProperties(Node $node): array
+    {
+        $nodeType = $node->getNodeType();
+        $nodeProperties = $node->getProperties();
+
+        $filteredProperties = [];
+        foreach ($nodeType->getProperties() as $propertyName => $configuration) {
+            if (
+                $nodeProperties instanceof ArrayPropertyCollection
+                    ? !$nodeProperties->offsetExists($propertyName)
+                    : !array_key_exists($propertyName, $nodeProperties)
+            ) {
+                // node doesn't have the property set
+                continue;
+            }
+
+            if (
+                array_key_exists("defaultValue", $configuration)
+                && $configuration["defaultValue"] === $nodeProperties[$propertyName]
+            ) {
+                // node property is the same as default
+                continue;
+            }
+
+            $propertyValue = $nodeProperties[$propertyName];
+            if ($propertyValue === null || $propertyValue === []) {
+                continue;
+            }
+            if (is_string($propertyValue) && trim($propertyValue) === "") {
+                continue;
+            }
+
+            if ($dataSourceIdentifier = $configuration["ui"]["inspector"]["editorOptions"]["dataSourceIdentifier"] ?? null) {
+                $filteredProperties[$propertyName] = $this->commentService->serialize(
+                    function ($indentation, $propertyName) use ($dataSourceIdentifier, $propertyValue) {
+                        return $indentation . '# ' . $propertyName . ' -> Datasource "' . $dataSourceIdentifier . '" with value ' . $this->valueToDebugString($propertyValue);
+                    }
+                );
+                continue;
+            }
+
+            if (($configuration["type"] ?? null) === "reference") {
+                $nodeTypesInReference = $configuration["ui"]["inspector"]["editorOptions"]["nodeTypes"] ?? ["Neos.Neos:Document"];
+                $filteredProperties[$propertyName] = $this->commentService->serialize(
+                    function ($indentation, $propertyName) use ($nodeTypesInReference, $propertyValue) {
+                        return $indentation . '# ' . $propertyName . ' -> Reference of NodeTypes (' . join(", ", $nodeTypesInReference) . ') with value ' . $this->valueToDebugString($propertyValue);
+                    }
+                );
+                continue;
+            }
+
+            if (($configuration["ui"]["inspector"]["editor"] ?? null) === 'Neos.Neos/Inspector/Editors/SelectBoxEditor') {
+                $selectBoxValues = array_keys($configuration["ui"]["inspector"]["editorOptions"]["values"] ?? []);
+                $filteredProperties[$propertyName] = $this->commentService->serialize(
+                    function ($indentation, $propertyName) use ($selectBoxValues, $propertyValue) {
+                        return $indentation . '# ' . $propertyName . ' -> SelectBox of ' . mb_strimwidth(json_encode($selectBoxValues), 0, 60, " ...]") . ' with value ' . $this->valueToDebugString($propertyValue);
+                    }
+                );
+                continue;
+            }
+
+            if (is_object($propertyValue) || (is_array($propertyValue) && is_object(array_values($propertyValue)[0] ?? null))) {
+                $filteredProperties[$propertyName] = $this->commentService->serialize(
+                    function ($indentation, $propertyName) use ($propertyValue) {
+                        return $indentation . '# ' . $propertyName . ' -> ' . $this->valueToDebugString($propertyValue);
+                    }
+                );
+                continue;
+            }
+
+            $filteredProperties[$propertyName] = $propertyValue;
+        }
+
+        return $filteredProperties;
+    }
+
+    private function valueToDebugString($value): string
+    {
+        if ($value instanceof Node) {
+            return 'Node(' . $value->getIdentifier() . ')';
+        }
+        if (is_iterable($value)) {
+            $name = null;
+            $entries = [];
+            foreach ($value as $key => $item) {
+                if ($item instanceof Node) {
+                    if ($name === null || $name === 'Nodes') {
+                        $name = 'Nodes';
+                    } else {
+                        $name = 'array';
+                    }
+                    $name = $name === null ;
+                    $entries[$key] = $item->getIdentifier();
+                    continue;
+                }
+                $name = 'array';
+                $entries[$key] = is_object($item) ? get_class($item) : json_encode($item);
+            }
+            return $name . '(' . join(', ', $entries) . ')';
+        }
+
+        if (is_object($value)) {
+            return 'object(' . get_class($value) . ')';
+        }
+        return json_encode($value);
+    }
+
+    /** @param array<Node|NodeInterface> $nodes */
+    private function nodeTemplateFromContentNodes(array $nodes): array
+    {
+        $template = [];
+        foreach ($nodes as $index => $node) {
+            assert($node instanceof Node);
+
+            $templatePart = array_filter([
+                "properties" => $this->nonDefaultConfiguredNodeProperties($node),
+                "childNodes" => $this->nodeTemplateFromContentNodes($node->getChildNodes("Neos.Neos:Content,Neos.Neos:ContentCollection"))
+            ]);
+
+            if ($templatePart === []) {
+                continue;
+            }
+
+            if ($node->isTethered()) {
+
+                $readableId = [
+                    "main" => "mainContentCollection",
+                    "footer" => "footerContentCollection"
+                ][$node->getName()] ?? $node->getName() . 'Tethered';
+
+                $template[$readableId] = array_merge([
+                    "name" => $node->getName()
+                ], $templatePart);
+                continue;
+            }
+
+            $template["content$index"] = array_merge([
+                "type" => $node->getNodeType()->getName()
+            ], $templatePart);
+        }
+
+        return $template;
+    }
+}

--- a/Configuration/Testing/NodeTypes.yaml
+++ b/Configuration/Testing/NodeTypes.yaml
@@ -71,7 +71,7 @@
               type: 'Flowpack.NodeTemplates:Content.Text'
               when: "${false}"
               properties:
-                text: "im never created"
+                text: "i'm never created"
 
 'Flowpack.NodeTemplates:Content.Columns.Two.WithContext':
   superTypes:

--- a/Configuration/Testing/NodeTypes.yaml
+++ b/Configuration/Testing/NodeTypes.yaml
@@ -37,3 +37,30 @@
               type: 'Flowpack.NodeTemplates:Content.Text'
               properties:
                 text: '<p>bar</p>'
+
+'Flowpack.NodeTemplates:Content.Columns.Two.Dynamic':
+  superTypes:
+    'Neos.Neos:Content': true
+  ui:
+    creationDialog:
+      elements:
+        text:
+          type: string
+          ui:
+            editor: Neos.Neos/Inspector/Editors/TextFieldEditor
+  childNodes:
+    column0:
+      type: 'Neos.Neos:ContentCollection'
+    column1:
+      type: 'Neos.Neos:ContentCollection'
+  options:
+    template:
+      childNodes:
+        tetheredColumns:
+          withItems: ["column0", "column1"]
+          name: "${item}"
+          childNodes:
+            content0:
+              type: 'Flowpack.NodeTemplates:Content.Text'
+              properties:
+                text: "${item == 'column0' ? '<p>foo</p>' : data.text}"

--- a/Configuration/Testing/NodeTypes.yaml
+++ b/Configuration/Testing/NodeTypes.yaml
@@ -40,7 +40,7 @@
               properties:
                 text: '<p>bar</p>'
 
-'Flowpack.NodeTemplates:Content.Columns.Two.Dynamic':
+'Flowpack.NodeTemplates:Content.Columns.Two.CreationDialogAndWithItems':
   superTypes:
     'Neos.Neos:Content': true
   ui:
@@ -64,5 +64,49 @@
           childNodes:
             content0:
               type: 'Flowpack.NodeTemplates:Content.Text'
+              when: "${true}"
               properties:
                 text: "${item == 'column0' ? '<p>foo</p>' : data.text}"
+            contentNever:
+              type: 'Flowpack.NodeTemplates:Content.Text'
+              when: "${false}"
+              properties:
+                text: "im never created"
+
+'Flowpack.NodeTemplates:Content.Columns.Two.WithContext':
+  superTypes:
+    'Neos.Neos:Content': true
+  childNodes:
+    column0:
+      type: 'Neos.Neos:ContentCollection'
+    column1:
+      type: 'Neos.Neos:ContentCollection'
+  options:
+    template:
+      withContext:
+        tagName: 'p'
+        booleanType: true
+        arrayType: ["foo"]
+      childNodes:
+        column0Tethered:
+          name: column0
+          childNodes:
+            content0:
+              type: 'Flowpack.NodeTemplates:Content.Text'
+              when: "${booleanType}"
+              withItems: "${arrayType}"
+              properties:
+                text: ${'<' + tagName + '>' + item + '</' + tagName + '>'}
+        column1Tethered:
+          name: column1
+          childNodes:
+            content0:
+              withContext:
+                otherBooleanType: true
+                oneItem: "${[false]}"
+                upperContext: "${'</' + tagName + '>'}"
+              when: "${otherBooleanType}"
+              withItems: "${oneItem}"
+              type: 'Flowpack.NodeTemplates:Content.Text'
+              properties:
+                text: "${'<p>bar' + upperContext}"

--- a/Configuration/Testing/NodeTypes.yaml
+++ b/Configuration/Testing/NodeTypes.yaml
@@ -11,6 +11,8 @@
   properties:
     text:
       type: string
+      ui:
+        label: "Text"
 
 'Flowpack.NodeTemplates:Content.Columns.Two':
   superTypes:

--- a/Configuration/Testing/NodeTypes.yaml
+++ b/Configuration/Testing/NodeTypes.yaml
@@ -1,0 +1,39 @@
+'Flowpack.NodeTemplates:Document.Page':
+  superTypes:
+    'Neos.Neos:Document': true
+  childNodes:
+    main:
+      type: 'Neos.Neos:ContentCollection'
+
+'Flowpack.NodeTemplates:Content.Text':
+  superTypes:
+    'Neos.Neos:Content': true
+  properties:
+    text:
+      type: string
+
+'Flowpack.NodeTemplates:Content.Columns.Two':
+  superTypes:
+    'Neos.Neos:Content': true
+  childNodes:
+    column0:
+      type: 'Neos.Neos:ContentCollection'
+    column1:
+      type: 'Neos.Neos:ContentCollection'
+  options:
+    template:
+      childNodes:
+        column0Tethered:
+          name: column0
+          childNodes:
+            content0:
+              type: 'Flowpack.NodeTemplates:Content.Text'
+              properties:
+                text: '<p>foo</p>'
+        column1Tethered:
+          name: column1
+          childNodes:
+            content0:
+              type: 'Flowpack.NodeTemplates:Content.Text'
+              properties:
+                text: '<p>bar</p>'

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ under the path "options.template".
 
 1. `composer require flowpack/nodetemplates`
 2. Add templates to your nodetypes configuration in NodeTypes.yaml, as described in the examples below
-3. Use the new React UI
+3. Or use the command to dump the template based on your workspace
 
 ## Hello world
 
@@ -145,7 +145,19 @@ The node creation depth can be configured via Settings.yaml with `nodeCreationDe
 Flowpack:
   NodeTemplates:
     nodeCreationDepth: 10
-``` 
+```
+
+## Create template from node subtree
+
+When creating a more complex node template (to create multiple pages and content elements) it can be helpful to take the current node subtree from your workspace as reference.
+For this case you can use the command:
+
+```sh
+flow nodeTemplate:createFromNodeSubtree <nodeIdentifier>
+```
+
+It will give you the output similar to the example above.
+References to Nodes and non-primitive property values are commented out in the YAML.
 
 ## More examples
 

--- a/Testing/Functional/Fixtures/TwoColumnPreset.yaml
+++ b/Testing/Functional/Fixtures/TwoColumnPreset.yaml
@@ -1,18 +1,20 @@
-template:
-  childNodes:
-    'Content Collection (column0)':
-      name: column0
+'{nodeTypeName}':
+  options:
+    template:
       childNodes:
-        content0:
-          type: 'Flowpack.NodeTemplates:Content.Text'
-          properties:
-            # Text
-            text: '<p>foo</p>'
-    'Content Collection (column1)':
-      name: column1
-      childNodes:
-        content0:
-          type: 'Flowpack.NodeTemplates:Content.Text'
-          properties:
-            # Text
-            text: '<p>bar</p>'
+        'Content Collection (column0)':
+          name: column0
+          childNodes:
+            content0:
+              type: 'Flowpack.NodeTemplates:Content.Text'
+              properties:
+                # Text
+                text: '<p>foo</p>'
+        'Content Collection (column1)':
+          name: column1
+          childNodes:
+            content0:
+              type: 'Flowpack.NodeTemplates:Content.Text'
+              properties:
+                # Text
+                text: '<p>bar</p>'

--- a/Testing/Functional/Fixtures/TwoColumnPreset.yaml
+++ b/Testing/Functional/Fixtures/TwoColumnPreset.yaml
@@ -6,6 +6,7 @@ template:
         content0:
           type: 'Flowpack.NodeTemplates:Content.Text'
           properties:
+            # Text
             text: '<p>foo</p>'
     column1Tethered:
       name: column1
@@ -13,4 +14,5 @@ template:
         content0:
           type: 'Flowpack.NodeTemplates:Content.Text'
           properties:
+            # Text
             text: '<p>bar</p>'

--- a/Testing/Functional/Fixtures/TwoColumnPreset.yaml
+++ b/Testing/Functional/Fixtures/TwoColumnPreset.yaml
@@ -1,6 +1,6 @@
 template:
   childNodes:
-    column0Tethered:
+    'Content Collection (column0)':
       name: column0
       childNodes:
         content0:
@@ -8,7 +8,7 @@ template:
           properties:
             # Text
             text: '<p>foo</p>'
-    column1Tethered:
+    'Content Collection (column1)':
       name: column1
       childNodes:
         content0:

--- a/Testing/Functional/Fixtures/TwoColumnPreset.yaml
+++ b/Testing/Functional/Fixtures/TwoColumnPreset.yaml
@@ -1,0 +1,16 @@
+template:
+  childNodes:
+    column0Tethered:
+      name: column0
+      childNodes:
+        content0:
+          type: 'Flowpack.NodeTemplates:Content.Text'
+          properties:
+            text: '<p>foo</p>'
+    column1Tethered:
+      name: column1
+      childNodes:
+        content0:
+          type: 'Flowpack.NodeTemplates:Content.Text'
+          properties:
+            text: '<p>bar</p>'

--- a/Testing/Functional/NodeTemplateTest.php
+++ b/Testing/Functional/NodeTemplateTest.php
@@ -79,7 +79,7 @@ class NodeTemplateTest extends FunctionalTestCase
                 'parentDomAddress' => [
                     'contextPath' => $targetNodeContextPath,
                 ],
-                'nodeType' => 'Flowpack.NodeTemplates:Content.Columns.Two',
+                'nodeType' => $toBeCreatedNodeTypeName = 'Flowpack.NodeTemplates:Content.Columns.Two',
                 'data' => $nodeCreationDialogProperties,
                 'baseNodeType' => '',
             ],
@@ -89,7 +89,7 @@ class NodeTemplateTest extends FunctionalTestCase
         self::assertInstanceOf(ChangeCollection::class, $changeCollection);
         $changeCollection->apply();
 
-        $createdNode = $targetNode->getChildNodes('Flowpack.NodeTemplates:Content.Columns.Two')[0];
+        $createdNode = $targetNode->getChildNodes($toBeCreatedNodeTypeName)[0];
 
         $dumpedYamlTemplate = $this->nodeTemplateDumper->createNodeTemplateYamlDumpFromSubtree($createdNode);
 
@@ -97,6 +97,45 @@ class NodeTemplateTest extends FunctionalTestCase
 
         self::assertStringEqualsFile(__DIR__ . '/Fixtures/TwoColumnPreset.yaml', $dumpedYamlTemplate);
     }
+
+    /** @test */
+    public function testDynamicNodeCreationMatchesSnapshot(): void
+    {
+        $nodeCreationDialogProperties = [
+            'text' => '<p>bar</p>'
+        ];
+
+        $targetNode = $this->homePageNode->getNode('main');
+
+        $targetNodeContextPath = $targetNode->getContextPath();
+
+        $changeCollectionSerialized = [[
+            'type' => 'Neos.Neos.Ui:CreateInto',
+            'subject' => $targetNodeContextPath,
+            'payload' => [
+                'parentContextPath' => $targetNodeContextPath,
+                'parentDomAddress' => [
+                    'contextPath' => $targetNodeContextPath,
+                ],
+                'nodeType' => $toBeCreatedNodeTypeName = 'Flowpack.NodeTemplates:Content.Columns.Two.Dynamic',
+                'data' => $nodeCreationDialogProperties,
+                'baseNodeType' => '',
+            ],
+        ]];
+
+        $changeCollection = (new ChangeCollectionConverter())->convertFrom($changeCollectionSerialized, null);
+        self::assertInstanceOf(ChangeCollection::class, $changeCollection);
+        $changeCollection->apply();
+
+        $createdNode = $targetNode->getChildNodes($toBeCreatedNodeTypeName)[0];
+
+        $dumpedYamlTemplate = $this->nodeTemplateDumper->createNodeTemplateYamlDumpFromSubtree($createdNode);
+
+        // file_put_contents(__DIR__ . '/Fixtures/TwoColumnPreset.yaml', $dumpedYamlTemplate);
+
+        self::assertStringEqualsFile(__DIR__ . '/Fixtures/TwoColumnPreset.yaml', $dumpedYamlTemplate);
+    }
+
 
     public function tearDown(): void
     {

--- a/Testing/Functional/NodeTemplateTest.php
+++ b/Testing/Functional/NodeTemplateTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\NodeTemplates\Tests\Functional;
+
+use Flowpack\NodeTemplates\NodeTemplateDumper\NodeTemplateDumper;
+use Neos\ContentRepository\Domain\Model\Node;
+use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Repository\WorkspaceRepository;
+use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\Flow\Tests\FunctionalTestCase;
+use Neos\Neos\Domain\Model\Site;
+use Neos\Neos\Domain\Repository\SiteRepository;
+use Neos\Neos\Ui\Domain\Model\ChangeCollection;
+use Neos\Neos\Ui\TypeConverter\ChangeCollectionConverter;
+
+class NodeTemplateTest extends FunctionalTestCase
+{
+    protected static $testablePersistenceEnabled = true;
+
+    private ContextFactoryInterface $contextFactory;
+
+    private Node $homePageNode;
+
+    private NodeTemplateDumper $nodeTemplateDumper;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->setupContentRepository();
+        $this->nodeTemplateDumper = $this->objectManager->get(NodeTemplateDumper::class);
+    }
+
+    private function setupContentRepository(): void
+    {
+        // Create an environment to create nodes.
+        $liveWorkspace = new Workspace('live');
+        $workspaceRepository = $this->objectManager->get(WorkspaceRepository::class);
+        $workspaceRepository->add($liveWorkspace);
+
+        $testSite = new Site('test-site');
+        $testSite->setSiteResourcesPackageKey('Test.Site');
+        $siteRepository = $this->objectManager->get(SiteRepository::class);
+        $siteRepository->add($testSite);
+
+        $this->persistenceManager->persistAll();
+        $this->contextFactory = $this->objectManager->get(ContextFactoryInterface::class);
+        $this->subgraph = $this->contextFactory->create(['workspaceName' => 'live']);
+
+        $rootNode = $this->subgraph->getRootNode();
+
+        $nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
+
+        $sitesRootNode = $rootNode->createNode('sites');
+        $testSiteNode = $sitesRootNode->createNode('test-site');
+        $this->homePageNode = $testSiteNode->createNode(
+            'homepage',
+            $nodeTypeManager->getNodeType('Flowpack.NodeTemplates:Document.Page')
+        );
+    }
+
+    /** @test */
+    public function testNodeCreationMatchesSnapshot(): void
+    {
+        $nodeCreationDialogProperties = [
+        ];
+
+        $targetNode = $this->homePageNode->getNode('main');
+
+        $targetNodeContextPath = $targetNode->getContextPath();
+
+        $changeCollectionSerialized = [[
+            'type' => 'Neos.Neos.Ui:CreateInto',
+            'subject' => $targetNodeContextPath,
+            'payload' => [
+                'parentContextPath' => $targetNodeContextPath,
+                'parentDomAddress' => [
+                    'contextPath' => $targetNodeContextPath,
+                ],
+                'nodeType' => 'Flowpack.NodeTemplates:Content.Columns.Two',
+                'data' => $nodeCreationDialogProperties,
+                'baseNodeType' => '',
+            ],
+        ]];
+
+        $changeCollection = (new ChangeCollectionConverter())->convertFrom($changeCollectionSerialized, null);
+        self::assertInstanceOf(ChangeCollection::class, $changeCollection);
+        $changeCollection->apply();
+
+        $createdNode = $targetNode->getChildNodes('Flowpack.NodeTemplates:Content.Columns.Two')[0];
+
+        $dumpedYamlTemplate = $this->nodeTemplateDumper->createNodeTemplateYamlDumpFromSubtree($createdNode);
+
+        // file_put_contents(__DIR__ . '/Fixtures/TwoColumnPreset.yaml', $dumpedYamlTemplate);
+
+        self::assertStringEqualsFile(__DIR__ . '/Fixtures/TwoColumnPreset.yaml', $dumpedYamlTemplate);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $this->inject($this->contextFactory, 'contextInstances', []);
+    }
+}

--- a/Testing/Functional/NodeTemplateTest.php
+++ b/Testing/Functional/NodeTemplateTest.php
@@ -104,7 +104,11 @@ class NodeTemplateTest extends FunctionalTestCase
 
         $dumpedYamlTemplate = $this->nodeTemplateDumper->createNodeTemplateYamlDumpFromSubtree($createdNode);
 
-        self::assertStringEqualsFile(__DIR__ . '/Fixtures/TwoColumnPreset.yaml', $dumpedYamlTemplate);
+        $snapshot = file_get_contents(__DIR__ . '/Fixtures/TwoColumnPreset.yaml');
+        self::assertSame(
+            str_replace('{nodeTypeName}', $toBeCreatedNodeTypeName->getValue(), $snapshot),
+            $dumpedYamlTemplate
+        );
     }
 
     /** @test */
@@ -122,7 +126,11 @@ class NodeTemplateTest extends FunctionalTestCase
 
         $dumpedYamlTemplate = $this->nodeTemplateDumper->createNodeTemplateYamlDumpFromSubtree($createdNode);
 
-        self::assertStringEqualsFile(__DIR__ . '/Fixtures/TwoColumnPreset.yaml', $dumpedYamlTemplate);
+        $snapshot = file_get_contents(__DIR__ . '/Fixtures/TwoColumnPreset.yaml');
+        self::assertSame(
+            str_replace('{nodeTypeName}', $toBeCreatedNodeTypeName->getValue(), $snapshot),
+            $dumpedYamlTemplate
+        );
     }
 
     /** @test */
@@ -138,7 +146,11 @@ class NodeTemplateTest extends FunctionalTestCase
 
         $dumpedYamlTemplate = $this->nodeTemplateDumper->createNodeTemplateYamlDumpFromSubtree($createdNode);
 
-        self::assertStringEqualsFile(__DIR__ . '/Fixtures/TwoColumnPreset.yaml', $dumpedYamlTemplate);
+        $snapshot = file_get_contents(__DIR__ . '/Fixtures/TwoColumnPreset.yaml');
+        self::assertSame(
+            str_replace('{nodeTypeName}', $toBeCreatedNodeTypeName->getValue(), $snapshot),
+            $dumpedYamlTemplate
+        );
     }
 
     public function tearDown(): void


### PR DESCRIPTION
`flow nodeTemplate:createFromNodeSubtree <nodeIdentifier>`

closes: #37

also adds a first near-e2e test ;) #33 

when creating a more complex node template, to create multiple pages and content elements, it can be helpful to take the current node subtree as reference. For this case a command controller would be great.

```sh
flow nodeTemplate:createFromNodeSubtree 136a646c-b2d5-4475-8e24-b25727aa7913 --workspaceName=live
```  


```yaml
Your.NodeType:
  options:
    template:
      childNodes:
        page0:
          name: page-0
          type: Foo.Bar:Page
          properties:
            title: 'my page'
            uriPathSegment: my-page
            # someReference -> Reference of NodeTypes (Neos.Neos:Document) with value Node(13f5e86b-7b0e-4a7f-9a8a-af6bdf1c1913)
          childNodes:
            page0:
              name: page-0
              type: Foo.Bar:Pag
              properties: ...
              childNodes:
                 mainContentCollection:
                   name: main
                   childNodes: ...
```

