### PR TITLE
FEATURE: `withContext` to define reusable variables and f.x. preprocess nodeCreation dialog items

### DIFF
--- a/Classes/NodeCreationHandler/TemplateNodeCreationHandler.php
+++ b/Classes/NodeCreationHandler/TemplateNodeCreationHandler.php
@@ -28,9 +28,8 @@ class TemplateNodeCreationHandler implements NodeCreationHandlerInterface
      *
      * @param NodeInterface $node The newly created node
      * @param array $data incoming data from the creationDialog
-     * @return void
      */
-    public function handle(NodeInterface $node, array $data)
+    public function handle(NodeInterface $node, array $data): void
     {
         if ($node->getNodeType()->hasConfiguration('options.template')) {
             $templateConfiguration = $node->getNodeType()->getConfiguration('options.template');
@@ -56,6 +55,5 @@ class TemplateNodeCreationHandler implements NodeCreationHandlerInterface
             'triggeringNode' => $node,
         ];
         $template->apply($node, $context);
-        return;
     }
 }

--- a/Classes/NodeCreationHandler/TemplatingDocumentTitleNodeCreationHandler.php
+++ b/Classes/NodeCreationHandler/TemplatingDocumentTitleNodeCreationHandler.php
@@ -25,12 +25,10 @@ class TemplatingDocumentTitleNodeCreationHandler implements NodeCreationHandlerI
     protected $nodeUriPathSegmentGenerator;
 
     /**
-     * @param NodeInterface $node
-     * @param array $data
      * @throws \Neos\Eel\Exception
      * @throws \Neos\Neos\Exception
      */
-    public function handle(NodeInterface $node, array $data)
+    public function handle(NodeInterface $node, array $data): void
     {
         $title = null;
         $uriPathSegment = null;
@@ -53,7 +51,7 @@ class TemplatingDocumentTitleNodeCreationHandler implements NodeCreationHandlerI
                 $title = $this->eelEvaluationService->evaluateEelExpression($titleTemplate, $context);
             }
         }
-        
+
         $uriPathSegmentTemplate = $node->getNodeType()->getOptions()['template']['properties']['uriPathSegment'] ?? '';
         if ($uriPathSegmentTemplate === '') {
             $uriPathSegment = $data['uriPathSegment'] ?? null;

--- a/Classes/Service/EelEvaluationService.php
+++ b/Classes/Service/EelEvaluationService.php
@@ -32,12 +32,10 @@ class EelEvaluationService
     /**
      * Evaluate an Eel expression.
      *
-     * @param string $expression The Eel expression to evaluate
-     * @param array $contextVariables
      * @return mixed The result of the evaluated Eel expression
      * @throws \Neos\Eel\Exception
      */
-    public function evaluateEelExpression($expression, $contextVariables)
+    public function evaluateEelExpression(string $expression, array $contextVariables)
     {
         if ($this->defaultContextVariables === null) {
             $this->defaultContextVariables = EelUtility::getDefaultContextVariables($this->defaultContext);

--- a/Classes/Template.php
+++ b/Classes/Template.php
@@ -108,17 +108,14 @@ class Template
      * Apply this template to the given node while providing context for EEL processing
      *
      * The entry point
-     *
-     * @param NodeInterface $node
-     * @param array $context
      */
-    public function apply(NodeInterface $node, array $context)
+    public function apply(NodeInterface $node, array $context): void
     {
         $context = $this->mergeContextAndWithContext($context);
         $this->applyTemplateOnNode($node, $context);
     }
 
-    private function applyTemplateOnNode(NodeInterface $node, array $context)
+    private function applyTemplateOnNode(NodeInterface $node, array $context): void
     {
         $context['node'] = $node;
 
@@ -140,10 +137,8 @@ class Template
     /**
      * @deprecated will be made internal and private
      * @internal
-     * @param NodeInterface $parentNode
-     * @param array $context
      */
-    public function createOrFetchAndApply(NodeInterface $parentNode, array $context)
+    public function createOrFetchAndApply(NodeInterface $parentNode, array $context): void
     {
         $context['parentNode'] = $parentNode;
 
@@ -199,11 +194,7 @@ class Template
         }
     }
 
-    /**
-     * @param array $context
-     * @return bool
-     */
-    public function isApplicable(array $context)
+    public function isApplicable(array $context): bool
     {
         $isApplicable = true;
         if ($this->when !== null) {
@@ -217,11 +208,8 @@ class Template
 
     /**
      * TODO: Handle EEL parsing for nested properties
-     *
-     * @param NodeInterface $node
-     * @param array $context
      */
-    protected function setProperties(NodeInterface $node, array $context)
+    protected function setProperties(NodeInterface $node, array $context): void
     {
         foreach ($this->properties as $propertyName => $propertyValue) {
             //evaluate Eel only on string properties
@@ -280,14 +268,10 @@ class Template
     /**
      * Signals that a node template has been applied to the given node.
      *
-     * @param NodeInterface $node
-     * @param array $context
-     * @param array $options
-     * @return void
      * @Flow\Signal
      * @api
      */
-    public function emitNodeTemplateApplied(NodeInterface $node, array $context, array $options)
+    public function emitNodeTemplateApplied(NodeInterface $node, array $context, array $options): void
     {
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,9 @@
     "name": "flowpack/nodetemplates",
     "license": "GPL-3.0+",
     "require": {
-        "neos/neos": "^5.0 || ^7.0 || ^8.0",
-        "neos/neos-ui": "*"
+        "php": ">=7.4",
+        "neos/neos": "^7.3 || ^8.0",
+        "neos/neos-ui": "^7.3 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
closes #36 

`withContext` takes an array of items whose value can be any yaml/php type and might also contain eel expressions.

```yaml
template:
  withContext:
    someText: '<p>foo</p>'
    processedData: "${String.trim(data.bla)}"
    booleanType: true
    arrayType: ["value"]
  childNodes:
    column0Tethered:
      name: column0
      childNodes:
        content0:
          type: 'Flowpack.NodeTemplates:Content.Text'
          when: "${booleanType}"
          withItems: "${arrayType}"
          properties:
            text: ${someText + processedData + item}
```

scopes and order of evaluation:
- inside `withContext` the "upper" context may be accessed in eel expressions, but sibling context values are not available

- `withContext` is evaluated before `when` and `withItems` so you can access computed values, that means the context `item` from `withItems` will not be available yet