### PR TITLE
TASK: Known exceptions are logged to the Neos.Ui and caught

### DIFF
--- a/Classes/Service/EelEvaluationService.php
+++ b/Classes/Service/EelEvaluationService.php
@@ -44,9 +44,9 @@ class EelEvaluationService
         try {
             return EelUtility::evaluateEelExpression($expression, $this->eelEvaluator, $contextVariables);
         } catch (ParserException $parserException) {
-            throw new \RuntimeException('EEL Expression in NodeType template could not be parsed.', 1684788574212, $parserException);
+            throw new EelException('EEL Expression in NodeType template could not be parsed.', 1684788574212, $parserException);
         } catch (\Exception $exception) {
-            throw new \RuntimeException(sprintf('EEL Expression "%s" in NodeType template caused an error.', $expression), 1684761760723, $exception);
+            throw new EelException(sprintf('EEL Expression "%s" in NodeType template caused an error.', $expression), 1684761760723, $exception);
         }
     }
 }

--- a/Classes/Service/EelException.php
+++ b/Classes/Service/EelException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Flowpack\NodeTemplates\Service;
+
+class EelException extends \Exception
+{
+}


### PR DESCRIPTION
A few example messages:

<img width="579" alt="image" src="https://github.com/Flowpack/Flowpack.NodeTemplates/assets/85400359/35792030-d252-4c6f-b01a-662f18ebd28d">


<img width="588" alt="image" src="https://github.com/Flowpack/Flowpack.NodeTemplates/assets/85400359/30f48adb-1afb-4b29-9b98-de8c9d88d871">


<img width="554" alt="image" src="https://github.com/Flowpack/Flowpack.NodeTemplates/assets/85400359/c1152108-843b-410e-91fe-3ff2fef5274f">
