### PR TITLE
BUGFIX: TransliterateNodeName to allow setting properties on a childNode with invalid name

### DIFF
--- a/Classes/Domain/NodeCreation/NodeCreationService.php
+++ b/Classes/Domain/NodeCreation/NodeCreationService.php
@@ -59,8 +59,11 @@ class NodeCreationService
 
     private function applyTemplateRecursively(Templates $templates, NodeInterface $parentNode, CaughtExceptions $caughtExceptions): void
     {
+        // `hasAutoCreatedChildNode` actually has a bug; it looks up the NodeName parameter against the raw configuration instead of the transliterated NodeName
+        // https://github.com/neos/neos-ui/issues/3527
+        $parentNodesAutoCreatedChildNodes = $parentNode->getNodeType()->getAutoCreatedChildNodes();
         foreach ($templates as $template) {
-            if ($template->getName() && $parentNode->getNodeType()->hasAutoCreatedChildNode($template->getName())) {
+            if ($template->getName() && isset($parentNodesAutoCreatedChildNodes[$template->getName()->__toString()])) {
                 $node = $parentNode->getNode($template->getName()->__toString());
                 if ($template->getType() !== null) {
                     $caughtExceptions->add(

--- a/Classes/Domain/TemplateConfiguration/TemplateConfigurationProcessor.php
+++ b/Classes/Domain/TemplateConfiguration/TemplateConfigurationProcessor.php
@@ -9,6 +9,7 @@ use Flowpack\NodeTemplates\Domain\Template\Template;
 use Flowpack\NodeTemplates\Domain\Template\Templates;
 use Neos\ContentRepository\Domain\NodeAggregate\NodeName;
 use Neos\ContentRepository\Domain\NodeType\NodeTypeName;
+use Neos\ContentRepository\Utility;
 use Neos\Flow\Annotations as Flow;
 
 /**
@@ -119,8 +120,8 @@ class TemplateConfigurationProcessor
         $type = $templatePart->processConfiguration('type');
         $name = $templatePart->processConfiguration('name');
         return new Template(
-            $type ? NodeTypeName::fromString($type) : null,
-            $name ? NodeName::fromString($name) : null,
+            $type !== null ? NodeTypeName::fromString($type) : null,
+            $name !== null ? NodeName::fromString(Utility::renderValidNodeName($name)) : null,
             $processedProperties,
             $childNodeTemplates
         );

--- a/Configuration/Testing/NodeTypes.TransliterateNodeName.yaml
+++ b/Configuration/Testing/NodeTypes.TransliterateNodeName.yaml
@@ -1,0 +1,44 @@
+# A valid node name must match this expression /^[a-z0-9\-]+$/
+# But Neos is so kind to still allow invalid configuration, and it transliterates the string
+# We must make sure that the same transliteration is applied to our childNodes to match the original
+---
+
+'Flowpack.NodeTemplates:Content.TransliterateNodeName':
+  superTypes:
+    'Neos.Neos:ContentCollection': true
+  childNodes:
+    my-node:
+      type: 'Flowpack.NodeTemplates:Content.Text'
+    fooBar:
+      type: 'Flowpack.NodeTemplates:Content.Text'
+    ö:
+      type: 'Flowpack.NodeTemplates:Content.Text'
+    'äBla北京=.§$Hä':
+      type: 'Flowpack.NodeTemplates:Content.Text'
+    '':
+      type: 'Flowpack.NodeTemplates:Content.Text'
+
+  options:
+    template:
+      childNodes:
+        legalNodeName:
+          name: my-node
+          properties:
+            text: "legalNodeName"
+        capitalsInName:
+          # leave out the type so we would provoke an error if it doesnt match the above childNode
+          name: fooBar
+          properties:
+            text: "capitalsInName"
+        onlyOneIllegalCharacter:
+          name: ö
+          properties:
+            text: "ö - was soll das"
+        everythingMixedTogether:
+          name: 'äBla北京=.§$Hä'
+          properties:
+            text: "everythingMixedTogether"
+        emptyString:
+          name: ''
+          properties:
+            text: "emptyString"

--- a/Tests/Functional/Fixtures/TransliterateNodeName.nodes.json
+++ b/Tests/Functional/Fixtures/TransliterateNodeName.nodes.json
@@ -1,0 +1,39 @@
+{
+    "childNodes": [
+        {
+            "nodeTypeName": "Flowpack.NodeTemplates:Content.Text",
+            "nodeName": "my-node",
+            "properties": {
+                "text": "legalNodeName"
+            }
+        },
+        {
+            "nodeTypeName": "Flowpack.NodeTemplates:Content.Text",
+            "nodeName": "foobar",
+            "properties": {
+                "text": "capitalsInName"
+            }
+        },
+        {
+            "nodeTypeName": "Flowpack.NodeTemplates:Content.Text",
+            "nodeName": "o",
+            "properties": {
+                "text": "\u00f6 - was soll das"
+            }
+        },
+        {
+            "nodeTypeName": "Flowpack.NodeTemplates:Content.Text",
+            "nodeName": "ablabei-jing-ss-ha",
+            "properties": {
+                "text": "everythingMixedTogether"
+            }
+        },
+        {
+            "nodeTypeName": "Flowpack.NodeTemplates:Content.Text",
+            "nodeName": "node-d41d8cd98f00b204e9800998ecf8427e",
+            "properties": {
+                "text": "emptyString"
+            }
+        }
+    ]
+}

--- a/Tests/Functional/Fixtures/TransliterateNodeName.template.json
+++ b/Tests/Functional/Fixtures/TransliterateNodeName.template.json
@@ -1,0 +1,45 @@
+{
+    "properties": [],
+    "childNodes": [
+        {
+            "type": null,
+            "name": "my-node",
+            "properties": {
+                "text": "legalNodeName"
+            },
+            "childNodes": []
+        },
+        {
+            "type": null,
+            "name": "foobar",
+            "properties": {
+                "text": "capitalsInName"
+            },
+            "childNodes": []
+        },
+        {
+            "type": null,
+            "name": "o",
+            "properties": {
+                "text": "\u00f6 - was soll das"
+            },
+            "childNodes": []
+        },
+        {
+            "type": null,
+            "name": "ablabei-jing-ss-ha",
+            "properties": {
+                "text": "everythingMixedTogether"
+            },
+            "childNodes": []
+        },
+        {
+            "type": null,
+            "name": "node-d41d8cd98f00b204e9800998ecf8427e",
+            "properties": {
+                "text": "emptyString"
+            },
+            "childNodes": []
+        }
+    ]
+}

--- a/Tests/Functional/Fixtures/TransliterateNodeName.yaml
+++ b/Tests/Functional/Fixtures/TransliterateNodeName.yaml
@@ -1,0 +1,29 @@
+'{nodeTypeName}':
+  options:
+    template:
+      childNodes:
+        legalNodeName:
+          name: my-node
+          properties:
+            # Text
+            text: legalNodeName
+        capitalsInName:
+          name: foobar
+          properties:
+            # Text
+            text: capitalsInName
+        'ö - was soll das':
+          name: o
+          properties:
+            # Text
+            text: 'ö - was soll das'
+        everythingMixedTogether:
+          name: ablabei-jing-ss-ha
+          properties:
+            # Text
+            text: everythingMixedTogether
+        emptyString:
+          name: node-d41d8cd98f00b204e9800998ecf8427e
+          properties:
+            # Text
+            text: emptyString

--- a/Tests/Functional/NodeTemplateTest.php
+++ b/Tests/Functional/NodeTemplateTest.php
@@ -178,6 +178,25 @@ class NodeTemplateTest extends FunctionalTestCase
         $this->assertNodeDumpAndTemplateDumpMatchSnapshot('TwoColumnPreset', $createdNode);
     }
 
+
+    /** @test */
+    public function transliterateNodeName(): void
+    {
+        $this->createNodeInto(
+            $targetNode = $this->homePageNode->getNode('main'),
+            $toBeCreatedNodeTypeName = NodeTypeName::fromString('Flowpack.NodeTemplates:Content.TransliterateNodeName'),
+            []
+        );
+
+        $this->assertLastCreatedTemplateMatchesSnapshot('TransliterateNodeName');
+
+        $createdNode = $targetNode->getChildNodes($toBeCreatedNodeTypeName->getValue())[0];
+
+        self::assertSame([], $this->getMessagesOfFeedbackCollection());
+        $this->assertNodeDumpAndTemplateDumpMatchSnapshot('TransliterateNodeName', $createdNode);
+    }
+
+
     /** @test */
     public function testNodeCreationWithDifferentPropertyTypes(): void
     {


### PR DESCRIPTION
A valid node name must match this expression /^[a-z0-9\-]+$/ But Neos is so kind to still allow invalid configuration, and it transliterates the string We must make sure that the same transliteration is applied to our childNode names to match the node names from the CR