### PR TITLE
FEATURE: Deprecate `triggeringNode` in favour of `site` and `parentNode`

### DIFF
--- a/Classes/Domain/TemplateNodeCreationHandler.php
+++ b/Classes/Domain/TemplateNodeCreationHandler.php
@@ -51,7 +51,9 @@ class TemplateNodeCreationHandler implements NodeCreationHandlerInterface
 
         $evaluationContext = [
             'data' => $data,
+            // deprectated will be removed in 3.0
             'triggeringNode' => $node,
+            'parentNode' => $node->getParent()
         ];
 
         $templateConfiguration = $node->getNodeType()->getConfiguration('options.template');

--- a/Classes/Domain/TemplateNodeCreationHandler.php
+++ b/Classes/Domain/TemplateNodeCreationHandler.php
@@ -51,9 +51,10 @@ class TemplateNodeCreationHandler implements NodeCreationHandlerInterface
 
         $evaluationContext = [
             'data' => $data,
-            // deprectated will be removed in 3.0
+            // deprecated will be removed in 3.0
             'triggeringNode' => $node,
-            'parentNode' => $node->getParent()
+            'site' => $node->getContext()->getCurrentSiteNode(),
+            'parentSourceNode' => $node->getParent(),
         ];
 
         $templateConfiguration = $node->getNodeType()->getConfiguration('options.template');

--- a/Classes/Domain/TemplateNodeCreationHandler.php
+++ b/Classes/Domain/TemplateNodeCreationHandler.php
@@ -9,6 +9,7 @@ use Flowpack\NodeTemplates\Domain\TemplateConfiguration\TemplateConfigurationPro
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Domain\Service\ContentContext;
 use Neos\Neos\Ui\NodeCreationHandler\NodeCreationHandlerInterface;
 
 class TemplateNodeCreationHandler implements NodeCreationHandlerInterface
@@ -49,12 +50,15 @@ class TemplateNodeCreationHandler implements NodeCreationHandlerInterface
             return;
         }
 
+        /** @var ContentContext $contentContext */
+        $contentContext = $node->getContext();
+
         $evaluationContext = [
             'data' => $data,
-            // deprecated will be removed in 3.0
+            // triggeringNode is deprecated and will be removed in 3.0
             'triggeringNode' => $node,
-            'site' => $node->getContext()->getCurrentSiteNode(),
-            'parentSourceNode' => $node->getParent(),
+            'site' => $contentContext->getCurrentSiteNode(),
+            'parentNode' => $node->getParent(),
         ];
 
         $templateConfiguration = $node->getNodeType()->getConfiguration('options.template');

--- a/README.md
+++ b/README.md
@@ -159,19 +159,23 @@ because it inspires a more declarative mood. The naming is inspired by Ansible.
 
 There are several variables available in the EEL context for example.
 
-| Variable name  | Type                 | Description                                                | Availability          |
-|----------------|----------------------|------------------------------------------------------------|-----------------------|
-| data           | array<string, mixed> | Data from the node creation dialog                         | Global                |
-| triggeringNode | NodeInterface        | The main node whose creation triggered template processing | Global                |
-| item           | mixed                | The current item inside a withItems loop                   | Inside withItems loop |
-| key            | string               | The current key inside a withItems loop                    | Inside withItems loop |
+| Variable name                | Type                   | Description                                                 | Availability            |
+|------------------------------|------------------------|-------------------------------------------------------------|-------------------------|
+| data                         | `array<string, mixed>` | Data from the node creation dialog                          | Global                  |
+| triggeringNode _@deprecated_ | `Node`                 | The main node whose creation triggered template processing  | Global                  |
+| parentNode                   | `Node`                 | The parent of the node the template is initially applied on | Global                  |
+| item                         | `mixed`                | The current item value inside a loop                        | Inside `withItems` loop |
+| key                          | `string`               | The current item key inside a loop                          | Inside `withItems` loop |
+
+> **Warning**
+> The behaviour of `parentNode` changed from version 1.x to 2.x
 
 ### Additional context
 
 You can add more context variables to a template via the ``withContext`` setting. ``withContext``
 takes an arbitrary array of items whose values might also contain EEL expressions:
 
-```
+```yaml
 template:
   withContext:
     someText: '<p>foo</p>'

--- a/README.md
+++ b/README.md
@@ -162,13 +162,14 @@ There are several variables available in the EEL context for example.
 | Variable name                | Type                   | Description                                                 | Availability            |
 |------------------------------|------------------------|-------------------------------------------------------------|-------------------------|
 | data                         | `array<string, mixed>` | Data from the node creation dialog                          | Global                  |
+| site                         | `Node`                 | The site node where the node creation was triggered         | Global                  |
 | triggeringNode _@deprecated_ | `Node`                 | The main node whose creation triggered template processing  | Global                  |
-| parentNode                   | `Node`                 | The parent of the node the template is initially applied on | Global                  |
+| parentSourceNode             | `Node`                 | The parent of the node the template is initially applied on | Global                  |
 | item                         | `mixed`                | The current item value inside a loop                        | Inside `withItems` loop |
 | key                          | `string`               | The current item key inside a loop                          | Inside `withItems` loop |
 
-> **Warning**
-> The behaviour of `parentNode` changed from version 1.x to 2.x
+> **Notice**
+> `triggeringNode` will be removed with Version 3
 
 ### Additional context
 

--- a/README.md
+++ b/README.md
@@ -159,17 +159,22 @@ because it inspires a more declarative mood. The naming is inspired by Ansible.
 
 There are several variables available in the EEL context for example.
 
-| Variable name                | Type                   | Description                                                 | Availability            |
-|------------------------------|------------------------|-------------------------------------------------------------|-------------------------|
-| data                         | `array<string, mixed>` | Data from the node creation dialog                          | Global                  |
-| site                         | `Node`                 | The site node where the node creation was triggered         | Global                  |
-| triggeringNode _@deprecated_ | `Node`                 | The main node whose creation triggered template processing  | Global                  |
-| parentSourceNode             | `Node`                 | The parent of the node the template is initially applied on | Global                  |
-| item                         | `mixed`                | The current item value inside a loop                        | Inside `withItems` loop |
-| key                          | `string`               | The current item key inside a loop                          | Inside `withItems` loop |
+| Variable name    | Type                   | Description                                                                   | Availability            |
+|------------------|------------------------|-------------------------------------------------------------------------------|-------------------------|
+| data             | `array<string, mixed>` | Data from the node creation dialog                                            | Global                  |
+| site             | `Node`                 | The site node in which the new node be created in                             | Global                  |
+| parentNode       | `Node`                 | The node where the new utmost node will be created inside                     | Global                  |
+| ~triggeringNode~ | `Node`                 | _Deprecated:_ The new node itself which is triggering the template processing | Global                  |
+| item             | `mixed`                | The current item value inside a loop                                          | Inside `withItems` loop |
+| key              | `string`               | The current item key inside a loop                                            | Inside `withItems` loop |
 
 > **Notice**
-> `triggeringNode` will be removed with Version 3
+> `triggeringNode` will be removed with version 3.0
+
+> **Warning**
+> The behaviour of `parentNode` changed from version 1.x to version 2.2
+> Previously it referenced the parent node of the current template part and its nesting.
+> With version 2.0 it was removed and 2.2 reintroduced the variable identifying the parent node of the first/utmost node that will be created.
 
 ### Additional context
 

--- a/Tests/Functional/Features/Variables/NodeTypes.Variables.yaml
+++ b/Tests/Functional/Features/Variables/NodeTypes.Variables.yaml
@@ -1,0 +1,13 @@
+# We test that `parentNode` is accessible in EEL
+---
+
+'Flowpack.NodeTemplates:Content.Variables':
+  superTypes:
+    'Neos.Neos:Content': true
+  properties:
+    text:
+      type: string
+  options:
+    template:
+      properties:
+        text: "${'ParentNodeType is of type ' + parentNode.nodeType.name + ' with name ' + parentNode.name}"

--- a/Tests/Functional/Features/Variables/NodeTypes.Variables.yaml
+++ b/Tests/Functional/Features/Variables/NodeTypes.Variables.yaml
@@ -1,4 +1,4 @@
-# We test that `parentNode` is accessible in EEL
+# We test that `parentSourceNode` and `site` are accessible in EEL
 ---
 
 'Flowpack.NodeTemplates:Content.Variables':
@@ -10,4 +10,4 @@
   options:
     template:
       properties:
-        text: "${'ParentNodeType is of type ' + parentNode.nodeType.name + ' with name ' + parentNode.name}"
+        text: "${'parentSourceNode(' + parentSourceNode.nodeType.name + ', ' + parentSourceNode.name + ') site(' + site.nodeType.name + ', ' + site.name + ')'}"

--- a/Tests/Functional/Features/Variables/NodeTypes.Variables.yaml
+++ b/Tests/Functional/Features/Variables/NodeTypes.Variables.yaml
@@ -1,4 +1,4 @@
-# We test that `parentSourceNode` and `site` are accessible in EEL
+# We test that `parentNode` and `site` are accessible in EEL
 ---
 
 'Flowpack.NodeTemplates:Content.Variables':
@@ -10,4 +10,4 @@
   options:
     template:
       properties:
-        text: "${'parentSourceNode(' + parentSourceNode.nodeType.name + ', ' + parentSourceNode.name + ') site(' + site.nodeType.name + ', ' + site.name + ')'}"
+        text: "${'parentNode(' + parentNode.nodeType.name + ', ' + parentNode.name + ') site(' + site.nodeType.name + ', ' + site.name + ')'}"

--- a/Tests/Functional/Features/Variables/Snapshots/Variables.nodes.json
+++ b/Tests/Functional/Features/Variables/Snapshots/Variables.nodes.json
@@ -1,0 +1,5 @@
+{
+    "properties": {
+        "text": "ParentNodeType is of type Neos.Neos:ContentCollection with name main"
+    }
+}

--- a/Tests/Functional/Features/Variables/Snapshots/Variables.nodes.json
+++ b/Tests/Functional/Features/Variables/Snapshots/Variables.nodes.json
@@ -1,5 +1,5 @@
 {
     "properties": {
-        "text": "ParentNodeType is of type Neos.Neos:ContentCollection with name main"
+        "text": "parentSourceNode(Neos.Neos:ContentCollection, main) site(unstructured, test-site)"
     }
 }

--- a/Tests/Functional/Features/Variables/Snapshots/Variables.nodes.json
+++ b/Tests/Functional/Features/Variables/Snapshots/Variables.nodes.json
@@ -1,5 +1,5 @@
 {
     "properties": {
-        "text": "parentSourceNode(Neos.Neos:ContentCollection, main) site(unstructured, test-site)"
+        "text": "parentNode(Neos.Neos:ContentCollection, main) site(unstructured, test-site)"
     }
 }

--- a/Tests/Functional/Features/Variables/Snapshots/Variables.template.json
+++ b/Tests/Functional/Features/Variables/Snapshots/Variables.template.json
@@ -1,0 +1,6 @@
+{
+    "properties": {
+        "text": "ParentNodeType is of type Neos.Neos:ContentCollection with name main"
+    },
+    "childNodes": []
+}

--- a/Tests/Functional/Features/Variables/Snapshots/Variables.template.json
+++ b/Tests/Functional/Features/Variables/Snapshots/Variables.template.json
@@ -1,6 +1,6 @@
 {
     "properties": {
-        "text": "ParentNodeType is of type Neos.Neos:ContentCollection with name main"
+        "text": "parentSourceNode(Neos.Neos:ContentCollection, main) site(unstructured, test-site)"
     },
     "childNodes": []
 }

--- a/Tests/Functional/Features/Variables/Snapshots/Variables.template.json
+++ b/Tests/Functional/Features/Variables/Snapshots/Variables.template.json
@@ -1,6 +1,6 @@
 {
     "properties": {
-        "text": "parentSourceNode(Neos.Neos:ContentCollection, main) site(unstructured, test-site)"
+        "text": "parentNode(Neos.Neos:ContentCollection, main) site(unstructured, test-site)"
     },
     "childNodes": []
 }

--- a/Tests/Functional/Features/Variables/Snapshots/Variables.yaml
+++ b/Tests/Functional/Features/Variables/Snapshots/Variables.yaml
@@ -1,0 +1,5 @@
+'{nodeTypeName}':
+  options:
+    template:
+      properties:
+        text: 'ParentNodeType is of type Neos.Neos:ContentCollection with name main'

--- a/Tests/Functional/Features/Variables/Snapshots/Variables.yaml
+++ b/Tests/Functional/Features/Variables/Snapshots/Variables.yaml
@@ -2,4 +2,4 @@
   options:
     template:
       properties:
-        text: 'ParentNodeType is of type Neos.Neos:ContentCollection with name main'
+        text: 'parentSourceNode(Neos.Neos:ContentCollection, main) site(unstructured, test-site)'

--- a/Tests/Functional/Features/Variables/Snapshots/Variables.yaml
+++ b/Tests/Functional/Features/Variables/Snapshots/Variables.yaml
@@ -2,4 +2,4 @@
   options:
     template:
       properties:
-        text: 'parentSourceNode(Neos.Neos:ContentCollection, main) site(unstructured, test-site)'
+        text: 'parentNode(Neos.Neos:ContentCollection, main) site(unstructured, test-site)'

--- a/Tests/Functional/Features/Variables/VariablesTest.php
+++ b/Tests/Functional/Features/Variables/VariablesTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flowpack\NodeTemplates\Tests\Functional\Features\Variables;
+
+use Flowpack\NodeTemplates\Tests\Functional\AbstractNodeTemplateTestCase;
+
+class VariablesTest extends AbstractNodeTemplateTestCase
+{
+    /** @test */
+    public function itMatchesSnapshot(): void
+    {
+        $createdNode = $this->createNodeInto(
+            $this->homePageMainContentCollectionNode,
+            'Flowpack.NodeTemplates:Content.Variables',
+            []
+        );
+
+        $this->assertLastCreatedTemplateMatchesSnapshot('Variables');
+
+        $this->assertNoExceptionsWereCaught();
+        $this->assertNodeDumpAndTemplateDumpMatchSnapshot('Variables', $createdNode);
+    }
+}


### PR DESCRIPTION
Introduce `parentNode` as reference to the parent of the node the template is initially applied on. The parent of the outermost node the Neos UI creates.

**New variables:**

| Variable name                | Type                   | Description                                                     | Availability            |
|------------------------------|------------------------|-----------------------------------------------------------------|-------------------------|
| site                         | `Node`                 | The site node in which the new node be created in               | Global                  |
| parentNode                   | `Node`                 | The node where the new utmost node will be created inside       | Global                  |
| ~triggeringNode~ | `Node`                 | _Deprecated:_ The new node itself which is triggering the template processing | Global                  |


> **Notice**
> `triggeringNode` will be removed with version 3.0

> **Warning**
> The behaviour of `parentNode` changed from version 1.x to version 2.2
> Previously it referenced the parent node of the current template part and its nesting.
> With version 2.0 it was removed and 2.2 reintroduced the variable identifying the parent node of the first/utmost node that will be created.



~We should wait with merging this, as `parentNode` meant something else in V1, and was breaking removed in V2.~